### PR TITLE
Fix "Could not get value of property"

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -47,12 +47,12 @@ class FrontendUser extends AbstractEntity
     /**
      * @var ObjectStorage<FrontendUserGroup>
      */
-    protected ObjectStorage $usergroup;
+    protected ?ObjectStorage $usergroup = null;
 
     /**
      * @var ObjectStorage<FileReference>
      */
-    protected ObjectStorage $image;
+    protected ?ObjectStorage $image = null;
 
     /**
      * Constructs a new Front-End User
@@ -154,7 +154,7 @@ class FrontendUser extends AbstractEntity
      *
      * @return ObjectStorage<FrontendUserGroup> An object storage containing the usergroup
      */
-    public function getUsergroup(): ObjectStorage
+    public function getUsergroup(): ?ObjectStorage
     {
         return $this->usergroup;
     }
@@ -454,7 +454,7 @@ class FrontendUser extends AbstractEntity
      *
      * @return ObjectStorage<FileReference>
      */
-    public function getImage(): ObjectStorage
+    public function getImage(): ?ObjectStorage
     {
         return $this->image;
     }

--- a/Classes/Domain/Model/FrontendUserGroup.php
+++ b/Classes/Domain/Model/FrontendUserGroup.php
@@ -31,7 +31,7 @@ class FrontendUserGroup extends AbstractEntity
     /**
      * @var ObjectStorage<FrontendUserGroup>
      */
-    protected ObjectStorage $subgroup;
+    protected ?ObjectStorage $subgroup = null;
 
     /**
      * Constructs a new Frontend User Group
@@ -121,7 +121,7 @@ class FrontendUserGroup extends AbstractEntity
      *
      * @return ObjectStorage<FrontendUserGroup> An object storage containing the subgroups
      */
-    public function getSubgroup(): ObjectStorage
+    public function getSubgroup(): ?ObjectStorage
     {
         return $this->subgroup;
     }


### PR DESCRIPTION
Could not get value of property "Mediadreams\MdNewsfrontend\Domain\Model\FrontendUserGroup::subgroup", make sure the property is either public or has a getter getSubgroup(), a hasser hasSubgroup() or an isser isSubgroup().

Resolves #35 

Solution:
Ensure nullable properties. See https://docs.typo3.org/m/typo3/reference-exceptions/main/en-us/Exceptions/1546632293.html